### PR TITLE
extract correct constructor from object

### DIFF
--- a/index.js
+++ b/index.js
@@ -225,7 +225,7 @@ class Sia {
           this.addNull(item);
           return;
         }
-        const { constructor } = item;
+        const { constructor } = Object.getPrototypeOf(item);
         switch (constructor) {
           case Object: {
             this.startObject();


### PR DESCRIPTION
Fix to correct serialization for example below:
`[
    {
        "constructor": "ScrollAction",
        "event": {
            "constructor": "Event",
            "target": {
                "cssSelector": null
            },
            "typeArg": "scroll",
            "eventInit": {
                "bubbles": true,
                "cancelable": false
            }
        },
        "timeout": 10000,
        "x": 0,
        "y": 900000
    }
]`

where "constructor" is key of serialized object.