### PR TITLE
Fix nested sets in maps and array of maps

### DIFF
--- a/index.js
+++ b/index.js
@@ -563,6 +563,7 @@ class DeSia {
           map.set(this.readBlock(), this.readBlock());
           curr = this.buffer[this.offset];
         }
+        this.offset++
         return map;
       }
 
@@ -573,6 +574,7 @@ class DeSia {
           set.add(this.readBlock());
           curr = this.buffer[this.offset];
         }
+        this.offset++
         return set;
       }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "lz4": "^0.6.3",
         "lzutf8": "^0.6.0",
         "msgpackr": "^1.4.2",
+        "nan": "^2.19.0",
         "node-fetch": "^2.6.1",
         "prettier": "^2.3.2",
         "pretty-bytes": "^5.4.0",
@@ -5190,9 +5191,9 @@
       }
     },
     "node_modules/nan": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
-      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==",
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.19.0.tgz",
+      "integrity": "sha512-nO1xXxfh/RWNxfd/XPfbIfFk5vgLsAxUR9y5O0cHMJu/AW9U95JLXqthYHjEp+8gQ5p96K9jUp8nbVOxCdRbtw==",
       "dev": true
     },
     "node_modules/nanomatch": {
@@ -11825,9 +11826,9 @@
       }
     },
     "nan": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
-      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==",
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.19.0.tgz",
+      "integrity": "sha512-nO1xXxfh/RWNxfd/XPfbIfFk5vgLsAxUR9y5O0cHMJu/AW9U95JLXqthYHjEp+8gQ5p96K9jUp8nbVOxCdRbtw==",
       "dev": true
     },
     "nanomatch": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "lz4": "^0.6.3",
     "lzutf8": "^0.6.0",
     "msgpackr": "^1.4.2",
+    "nan": "^2.19.0",
     "node-fetch": "^2.6.1",
     "prettier": "^2.3.2",
     "pretty-bytes": "^5.4.0",

--- a/tests/sia.test.js
+++ b/tests/sia.test.js
@@ -33,6 +33,59 @@ test("Serialize maps", () => {
   expect(deserialized).toEqual(map);
 });
 
+test("Serialize map of set", () => {
+  const map = new Map([
+    [1, new Set([1, 2])],
+    [2, new Set([3, 4])],
+  ]);
+  const serialized = sia(map);
+  const deserialized = desia(serialized);
+  expect(deserialized).toBeInstanceOf(Map);
+  expect(deserialized).toEqual(map);
+});
+
+test("Serialize set of set", () => {
+  const map = new Set([
+    new Set([1, 2]), new Set([3, 4])
+  ]);
+  const serialized = sia(map);
+  const deserialized = desia(serialized);
+  expect(deserialized).toBeInstanceOf(Set);
+  expect(deserialized).toEqual(map);
+});
+
+test("Serialize map of map", () => {
+  const map = new Map([
+    [1, new Map([[1, 2]])],
+    [1, new Map([[3, 4]])]
+  ]);
+  const serialized = sia(map);
+  const deserialized = desia(serialized);
+  expect(deserialized).toBeInstanceOf(Map);
+  expect(deserialized).toEqual(map);
+});
+
+test("Serialize array of maps", () => {
+  const maps = [new Map([[1, 2], [3, 4]]), new Map([[5, 6], [7, 8]])];
+  const serialized = sia(maps);
+  const deserialized = desia(serialized);
+  expect(deserialized).toEqual(maps);
+});
+
+test("Serialize array of sets", () => {
+  const sets = [new Set([1, 2, 3]), new Set()];
+  const serialized = sia(sets);
+  const deserialized = desia(serialized);
+  expect(deserialized).toEqual(sets);
+});
+
+test("Serialize empty collections", () => {
+  const emptyCollections = [new Set(), new Set(), new Map(), []];
+  const serialized = sia(emptyCollections);
+  const deserialized = desia(serialized);
+  expect(deserialized).toEqual(emptyCollections);
+});
+
 test("Serialize integers", () => {
   const integers = [0x10, 0x100, 0x10000, 0x100000000];
   const serialized = sia(integers);


### PR DESCRIPTION
When serializing and deserializing nested sets within maps (as values), this library fails with an error such as `Unsupported type: 55`. See new test case `Serialize map of set`. Similar holds for arrays of maps, see test case `Serialize array of maps`. 

Both is fixed by advancing `this.offset` after the `Set` or `Map` block has been read. I've also added more "edge case" like test cases, I hope it's fine that I did not duplicate them into `sia.grow.test.js`.

Also, this PR explicitly bumps `nan` package to 2.19.0, fixing `npm install` on my machine. Otherwise it fails due to [this bug](https://github.com/nodejs/nan/pull/941).